### PR TITLE
A few minor improvements

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -139,9 +139,9 @@ Assume Date.today is 1st May 2009
 ##### financial_quarter -> Returns Q1, Q2, Q3, Q4 depending on where the date falls
 
     Date.today.financial_quarter
-    => Q1
+    => Q1 2009
     Date.today.beginning_of_year.financial_quarter
-    => Q4
+    => Q4 2009
 
 ##### financial_half -> Returns H1, H2 depending on where the date falls
 
@@ -160,12 +160,23 @@ Assume Date.today is 1st May 2009
     Date.today.next_financial_half
     => 1st October 2009
 
-##### beginning_of_financial_quarter -> Takes you to the beginning of the current financial quarter
+##### beginning_of_financial_quarter -> Takes you to the beginning of a quarter in the current financial year (defaults to current quarter)
 
     Date.today.beginning_of_financial_quarter
     => 1st April 2009
     Date.today.beginning_of_year.beginning_of_financial_quarter
     => 1st Jan 2009
+    Date.today.beginning_of_financial_quarter(3)
+    => 1st July 2009
+
+##### end_of_financial_quarter -> Takes you to the end of a quarter in the current financial year (defaults to current quarter)
+
+    Date.today.end_of_financial_quarter
+    => 30th June 2009
+    Date.today.beginning_of_year.end_of_financial_quarter
+    => 31st March 2009
+    Date.today.end_of_financial_quarter(3)
+    => 30th September 2009
 
 ##### beginning_of_financial_half -> Takes you to the beginning of the current financial half
 

--- a/lib/rising_sun/fiscali.rb
+++ b/lib/rising_sun/fiscali.rb
@@ -60,38 +60,17 @@ module RisingSun
 
     def beginning_of_financial_year
       year = self.class.uses_forward_year? ? financial_year - 1 : financial_year
-      change(:year => year, :month => start_month, :day => 1)
+      change(:year => year, :month => start_month, :day => 1).beginning_of_month
     end
 
     def end_of_financial_year
       (beginning_of_financial_year + 1.year - 1.month).end_of_month
     end
 
-    alias :beginning_of_financial_q1 :beginning_of_financial_year
-    def end_of_financial_q1
-      end_of_financial_year - 9.months
+    (1..4).each do |q|
+      define_method("beginning_of_financial_q#{q}"){ beginning_of_financial_quarter q }
+      define_method("end_of_financial_q#{q}"){ end_of_financial_quarter q }
     end
-
-    def beginning_of_financial_q2
-      beginning_of_financial_year + 3.months
-    end
-
-    def end_of_financial_q2
-      end_of_financial_year - 6.months
-    end
-
-    def beginning_of_financial_q3
-      beginning_of_financial_year + 6.months
-    end
-
-    def end_of_financial_q3
-      end_of_financial_year - 3.months
-    end
-
-    def beginning_of_financial_q4
-      beginning_of_financial_year + 9.months
-    end
-    alias :end_of_financial_q4 :end_of_financial_year
 
     alias :beginning_of_financial_h1 :beginning_of_financial_year
     alias :end_of_financial_h1 :end_of_financial_q2
@@ -115,8 +94,14 @@ module RisingSun
       beginning_of_financial_year.months_since(((months_between / 6).floor + 1) * 6)
     end
 
-    def beginning_of_financial_quarter
-      beginning_of_financial_year.months_since(((months_between / 3).floor) * 3)
+    def beginning_of_financial_quarter(quarter = nil)
+      quarter = (months_between / 3).floor + 1 unless quarter.in? 1..4
+      beginning_of_financial_year.advance(months: (quarter - 1) * 3).beginning_of_month
+    end
+
+    def end_of_financial_quarter(quarter = nil)
+      quarter = (months_between / 3).floor + 1 unless quarter.in? 1..4
+      beginning_of_financial_year.advance(months: quarter * 3 - 1).end_of_month
     end
 
     def beginning_of_financial_half
@@ -149,6 +134,5 @@ module RisingSun
     def start_month
       self.class.fy_start_month || FY_START_MONTH
     end
-
   end
 end

--- a/spec/fiscali_spec.rb
+++ b/spec/fiscali_spec.rb
@@ -54,8 +54,10 @@ describe "fiscali" do
 
   context "should report correct date field" do
     before(:each) do
+      Date.fiscal_zone = :india
       @d = Date.new(2009,1,1)
     end
+
     it "should report correct financial year" do
       @d.financial_year.should eql(2008)
     end
@@ -81,6 +83,15 @@ describe "fiscali" do
       @d.end_of_financial_q2.should eql(Date.new(2008,9,30))
       @d.end_of_financial_q3.should eql(Date.new(2008,12,31))
       @d.end_of_financial_q4.should eql(Date.new(2009,3,31))
+
+      Date.fiscal_zone = :us 
+
+      @d.end_of_financial_h1.should eql(Date.new(2009,3,31))
+      @d.end_of_financial_h2.should eql(Date.new(2009,9,30))
+      @d.end_of_financial_q1.should eql(Date.new(2008,12,31))
+      @d.end_of_financial_q2.should eql(Date.new(2009,3,31))
+      @d.end_of_financial_q3.should eql(Date.new(2009,6,30))
+      @d.end_of_financial_q4.should eql(Date.new(2009,9,30))
     end
 
     it "should report financial quarters" do
@@ -114,6 +125,33 @@ describe "fiscali" do
       Date.new(2009,10,30).previous_financial_quarter.should eql(Date.new(2009,7,1))
     end
 
+  end
+
+  context "should report correct timestamp" do
+    before(:each) do
+      Time.fiscal_zone = :india
+      @t = Time.new(2009,1,1,12,1,1)
+    end
+
+    it "should report beginning of year/half/quarter with timestamp at beginning of day" do
+      @t.beginning_of_financial_year.should eql(Time.new(2008,4,1,0,0,0))
+      @t.beginning_of_financial_h1.should eql(Time.new(2008,4,1,0,0,0))
+      @t.beginning_of_financial_h2.should eql(Time.new(2008,10,1,0,0,0))
+      @t.beginning_of_financial_q1.should eql(Time.new(2008,4,1,0,0,0))
+      @t.beginning_of_financial_q2.should eql(Time.new(2008,7,1,0,0,0))
+      @t.beginning_of_financial_q3.should eql(Time.new(2008,10,1,0,0,0))
+      @t.beginning_of_financial_q4.should eql(Time.new(2009,1,1,0,0,0))
+    end
+
+    it "should report end of year/half/quarter with timestamp at end of day" do
+      @t.end_of_financial_year.should eql(Time.new(2009,3,31).end_of_day)
+      @t.end_of_financial_h1.should eql(Time.new(2008,9,30).end_of_day)
+      @t.end_of_financial_h2.should eql(Time.new(2009,3,31).end_of_day)
+      @t.end_of_financial_q1.should eql(Time.new(2008,6,30).end_of_day)
+      @t.end_of_financial_q2.should eql(Time.new(2008,9,30).end_of_day)
+      @t.end_of_financial_q3.should eql(Time.new(2008,12,31).end_of_day)
+      @t.end_of_financial_q4.should eql(Time.new(2009,3,31).end_of_day)
+    end
   end
 
   it "should not rely on app being single threaded" do


### PR DESCRIPTION
Thanks for writing this gem.  It's been really useful.  I ran into a couple little issues that led to the changes in this pull request.  Here's a rundown of what I did:
-  I found that the `end_of_financial_q*` and `end_of_financial_h*` methods were returning the wrong dates in some cases.  In particular, it would happen when the last month of the financial year only had 30 days in it.
  
  ```
  Date.fiscal_zone = :us
  Date.new(2009,1,1).end_of_financial_q1
  => Tue, 30 Dec 2008
  ```
-  I improved the accuracy of the `beginning_of_` and `end_of_` methods when used with `Time` or `DateTime` instances.  They now set the timestamp to the beginning or end of the day (depending on which method you're using).  This matches the behavior of similar methods in ActiveSupport, such as `end_of_month`.  
-  I added a parameter to the `beginning_of_financial_quarter` method, allowing you to specify which quarter of the instance's financial year you want the beginning of.  If no argument is passed in, it defaults to the original behavior of using the current quarter for the instance.  Adding the parameter also allowed for the `beginning_of_financial_q*` methods to be dynamically defined.
-  I added an `end_of_financial_quarter` method to match the `beginning_of_financial_quarter` method.
-  The documentation on the README for the `financial_quarter` method was incorrect, as it actually includes the year in the output.  
