### PR TITLE
Change financial_year_start to honor @fy_forward

### DIFF
--- a/lib/rising_sun/fiscali.rb
+++ b/lib/rising_sun/fiscali.rb
@@ -29,7 +29,7 @@ module RisingSun
       end
 
       def financial_year_start(year=Date.today.year)
-        new(year,fy_start_month,1)
+        uses_forward_year? ? new(year - 1,fy_start_month,1) : new(year,fy_start_month,1)
       end
 
       def financial_months

--- a/spec/fiscali_spec.rb
+++ b/spec/fiscali_spec.rb
@@ -50,6 +50,15 @@ describe "fiscali" do
       @d = Date.new(2009,6,1)
       @d.beginning_of_financial_year.should eql(Date.new(2009,4,1))
     end
+
+    it "should report financial year start" do
+      Date.fiscal_zone = :india
+      Date.use_forward_year!
+      this_year = Date.today.year
+      Date.financial_year_start.should eql(Date.new(this_year-1,4,1))
+
+      Date.financial_year_start(2009).should eql(Date.new(2008,4,1))
+    end
   end
 
   context "should report correct date field" do


### PR DESCRIPTION
Found that financial_year_start doesn't return the correct financial year when Year Forward is in use.

Here's a quick edit to check and honor that configuration and a test to go with it.
