### PR TITLE
Explicitly declare use of the MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,21 @@
-Copyright (c) 2009 asanghi
+The MIT License (MIT)
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Copyright (c) 2009 Aditya Sanghi
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.markdown
+++ b/README.markdown
@@ -199,7 +199,6 @@ Assume Date.today is 1st May 2009
     Date.today.beginning_of_year.previous_financial_quarter
     => 1st Apr 2008
 
-
 ## Contributors
 
 * [@reed](https://github.com/reed)
@@ -207,3 +206,6 @@ Assume Date.today is 1st May 2009
 * [@rshallit](https://github.com/rshallit)
 * [@asanghi](https://github.com/asanghi)
 
+## License
+
+Fiscali is released under the [MIT License](http://www.opensource.org/licenses/MIT).

--- a/fiscali.gemspec
+++ b/fiscali.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Fiscal Year Date Functions}
   gem.summary       = %q{Fiscal Year Date Functions}
   gem.homepage      = "https://github.com/asanghi/fiscali"
+  gem.license       = 'MIT'
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
@@ -20,4 +21,3 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 2.8'
 end
-


### PR DESCRIPTION
I noticed that the LICENSE for this project is MIT (good!) but it wasn't obvious—I had to go compare it to the text on the website to be sure. I just wanted to reinforce that it's using the MIT License, so that's easier to know at-a-glance.

Changes:

1. Add to the gemspec file.
2. Use the exact text of the MIT License from their website
(http://opensource.org/licenses/MIT).
3. Explicitly declare it’s the MIT License at the top of the LICENSE
file.
4. Add license information to the bottom of the README as per
convention.