### PR TITLE
Return the same financial year when the start month is January

### DIFF
--- a/lib/rising_sun/fiscali.rb
+++ b/lib/rising_sun/fiscali.rb
@@ -51,7 +51,9 @@ module RisingSun
     end
 
     def financial_year
-      if self.class.uses_forward_year?
+      if start_month == 1
+        self.year
+      elsif self.class.uses_forward_year?
         self.month < start_month ? self.year : self.year + 1
       else
         self.month < start_month ? self.year - 1 : self.year

--- a/spec/fiscali_spec.rb
+++ b/spec/fiscali_spec.rb
@@ -160,4 +160,26 @@ describe "fiscali" do
     thread.join
     expect(thread['my_fiscal_zone']).to eql(:india)
   end
+
+  context "when the start month is January" do
+    around :each do |example|
+      old_fy_start_month = Date.fy_start_month
+      Date.fy_start_month = 1
+      @date = Date.new(2014, 1, 1)
+      example.run
+      Date.fy_start_month = old_fy_start_month
+    end
+
+    it "returns the date's year as the financial year" do
+      expect(@date.financial_year).to eql(2014)
+    end
+
+    context "when using forward year" do
+      it "returns the date's year as the financial year" do
+        Date.use_forward_year!
+        expect(@date.financial_year).to eql(2014)
+        Date.reset_forward_year!
+      end
+    end
+  end
 end


### PR DESCRIPTION
If the start of the fiscal year is January, the financial year should be the
same whether you're using forward year or not.

Forward year basically depends on when the fiscal year started (non-forward)
or ended (forward). Since a January start means that the year starts and ends in
the same year, the financial year should be exactly that year.