### PR TITLE
Check for January start when calculating beginning of FY

### DIFF
--- a/lib/rising_sun/fiscali.rb
+++ b/lib/rising_sun/fiscali.rb
@@ -51,7 +51,7 @@ module RisingSun
     end
 
     def financial_year
-      if start_month == 1
+      if january_start_month?
         self.year
       elsif self.class.uses_forward_year?
         self.month < start_month ? self.year : self.year + 1
@@ -61,8 +61,7 @@ module RisingSun
     end
 
     def beginning_of_financial_year
-      year = self.class.uses_forward_year? ? financial_year - 1 : financial_year
-      change(:year => year, :month => start_month, :day => 1).beginning_of_month
+      change(:year => year_of_financial_year_beginning, :month => start_month).beginning_of_month
     end
 
     def end_of_financial_year
@@ -127,6 +126,18 @@ module RisingSun
     end
 
     private
+
+    def year_of_financial_year_beginning
+      if self.class.uses_forward_year? && !january_start_month?
+        financial_year - 1
+      else
+        financial_year
+      end
+    end
+
+    def january_start_month?
+      start_month == 1
+    end
 
     def months_between
       soy = self.beginning_of_financial_year

--- a/spec/fiscali_spec.rb
+++ b/spec/fiscali_spec.rb
@@ -175,10 +175,22 @@ describe "fiscali" do
     end
 
     context "when using forward year" do
-      it "returns the date's year as the financial year" do
+      around :each do |example|
         Date.use_forward_year!
-        expect(@date.financial_year).to eql(2014)
+        example.run
         Date.reset_forward_year!
+      end
+
+      it "returns the date's year as the financial year" do
+        expect(@date.financial_year).to eql(2014)
+      end
+
+      it "returns the date itself as the beginning_of_financial_year" do
+        expect(@date.beginning_of_financial_year).to eql(@date)
+      end
+
+      it "returns the date itself as the end_of_financial_year" do
+        expect(@date.end_of_financial_year).to eql(Date.new(2014, 12, 31))
       end
     end
   end


### PR DESCRIPTION
As a consequence of adjusting `financial_year` to take into account a January
starting month, `beginning_of_financial_year` and `end_of_financial_year` were
also thrown off when we use forward year. These methods will now also do the
same check.