### PR TITLE
Set 'day => 1' at beginning_of_financial_year

### DIFF
--- a/lib/rising_sun/fiscali.rb
+++ b/lib/rising_sun/fiscali.rb
@@ -61,7 +61,7 @@ module RisingSun
     end
 
     def beginning_of_financial_year
-      change(:year => year_of_financial_year_beginning, :month => start_month).beginning_of_month
+      change(:year => year_of_financial_year_beginning, :month => start_month, :day => 1).beginning_of_month
     end
 
     def end_of_financial_year

--- a/spec/fiscali_spec.rb
+++ b/spec/fiscali_spec.rb
@@ -124,7 +124,18 @@ describe "fiscali" do
       expect(Date.new(2009,6,1).previous_financial_half).to eql(Date.new(2008,10,1))
       expect(Date.new(2009,10,30).previous_financial_quarter).to eql(Date.new(2009,7,1))
     end
+  end
 
+  context 'when date is end of month' do
+    before do
+      Date.fiscal_zone = :india
+      @d = Date.new(2009, 3, 31)
+    end
+
+    it "should report correct beginning and of financial year" do
+      expect(@d.beginning_of_financial_year).to eql(Date.new(2008,4,1))
+      expect(@d.end_of_financial_year).to eql(Date.new(2009,3,31))
+    end
   end
 
   context "should report correct timestamp" do


### PR DESCRIPTION
````ruby
$> Date.new(2016, 3, 30).end_of_financial_year
=> Thu, 31 Mar 2016
$> Date.new(2016, 3, 31).end_of_financial_year
ArgumentError: invalid date

$> Date.new(2016, 3, 30).beginning_of_financial_year
=> Wed, 01 Apr 2015
$> Date.new(2016, 3, 31).beginning_of_financial_year
ArgumentError: invalid date
```

since #17 
https://github.com/asanghi/fiscali/pull/17/files#diff-5af0bb6a60db55df5f9f823c85549547L65