### PR TITLE
add method to get calendar year for a date

### DIFF
--- a/lib/rising_sun/fiscali.rb
+++ b/lib/rising_sun/fiscali.rb
@@ -125,6 +125,22 @@ module RisingSun
       end
     end
 
+    def calendar_year(date)
+      if Date.uses_forward_year?
+        if date.month >= Date.fy_start_month
+          date.financial_year
+        else
+          date.financial_year - 1
+        end
+      else
+        if date.month >= Date.fy_start_month
+          date.financial_year + 1
+        else
+          date.financial_year
+        end
+      end
+    end
+
     private
 
     def year_of_financial_year_beginning

--- a/lib/rising_sun/fiscali.rb
+++ b/lib/rising_sun/fiscali.rb
@@ -125,21 +125,21 @@ module RisingSun
       end
     end
 
-    def calendar_year(date)
-      if Date.uses_forward_year?
-        if date.month >= Date.fy_start_month
-          date.financial_year
-        else
-          date.financial_year - 1
-        end
+  def calendar_year_for_fiscal_date(the_date, the_month)
+    if Date.uses_forward_year?
+      if the_month >= Date.fy_start_month
+        the_date.financial_year - 1
       else
-        if date.month >= Date.fy_start_month
-          date.financial_year + 1
-        else
-          date.financial_year
-        end
+        the_date.financial_year
+      end
+    else
+      if the_month >= Date.fy_start_month
+        the_date.financial_year
+      else
+        the_date.financial_year + 1
       end
     end
+  end
 
     private
 


### PR DESCRIPTION
We found the need for a method that would take a date and return the calendar year.  This method take a date and month; the date is used to determine the calendar year, and the month (along with whether or not you have `forward_year` setup or not) determines the fiscal year.
