### PR TITLE
Add all_financial_quarter and all_financial_year to match ActiveSupport

### DIFF
--- a/lib/rising_sun/fiscali.rb
+++ b/lib/rising_sun/fiscali.rb
@@ -117,6 +117,14 @@ module RisingSun
       beginning_of_financial_half.months_ago(6)
     end
 
+    def all_financial_quarter
+      beginning_of_financial_quarter..end_of_financial_quarter
+    end
+
+    def all_financial_year
+      beginning_of_financial_year..end_of_financial_year
+    end
+
     def financial_month_of(month)
       if month < start_month
         Date.new(year+1,month,1)

--- a/spec/fiscali_spec.rb
+++ b/spec/fiscali_spec.rb
@@ -205,4 +205,18 @@ describe "fiscali" do
       end
     end
   end
+
+  context 'all_* methods' do
+    it 'returns a range of the entire financial period' do
+      date = Date.today
+      range = date.all_financial_quarter
+      expect(range.first).to eql(date.beginning_of_financial_quarter)
+      expect(range.last).to eql(date.end_of_financial_quarter)
+
+      range = date.all_financial_year
+
+      expect(range.first).to eql(date.beginning_of_financial_year)
+      expect(range.last).to eql(date.end_of_financial_year)
+    end
+  end
 end


### PR DESCRIPTION
I noticed that a couple of helper methods provided in ActiveSupport were not available.

This adds the two I need.


BTW, is this gem still maintained? I'd be happy to help if need be.

Thanks for all your hard work, I appreciate this gem.